### PR TITLE
Add missing grunt-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "update-notifier": "0.2.2"
   },
   "devDependencies": {
+    "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-deps-ok": "0.3.0",


### PR DESCRIPTION
Can't run `npm-test` without `grunt-cli`.
