### PR TITLE
Implements custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,33 @@ save to `.dont-break.json` and check.
 
 The above commands overwrite `.dont-break.json` file.
 
-## Custom test command (in progress)
+## Custom test command
 
-You can specify a custom test command per dependent module. Separate the name of the module
-from the test command using `:` For example, to run `grunt test` for `foo-module-name`,
-but default command for module `bar-name`, list in `.dont-break.json` the following:
+You can specify a custom test command per dependent module, as well. Instead of
+specifying the string of the dependency to be installed, provide an object with
+the `name` and `command` you wish to execute. If the module to be tested should
+be cloned via git instead of installed from npm, specify that by setting the
+`repoUrl` property.
 
+For example, to run `npm run test:ci` for `foo-module-name` and hte default
+command for module `bar-name`, you could configure the following
+`.dont-break.json`:
+
+```json
+[
+  {
+    "name": "foo-module-name",
+    "repoUrl": "https://github.com/foo/foo.js",
+    "command": "npm run test:ci"
+  },
+  "bar-name"
+]
 ```
-foo-module-name: grunt test
-bar-name
-```
 
-You can also specify a longer installation time out, in seconds, using CLI option
+## Timeout
+
+You can also specify a longer installation time out, in seconds, using option
+`--timeout` from the command-line. The default is 10 seconds.
 
 ```
 dont-break --timeout 30


### PR DESCRIPTION
Users can now specify custom commands. This had been documented previously as using a `:` separator between module name and command in the string, but it was not implemented. Additionally, that strategy wouldn't have worked for git-repo-URLs (as a protocol or port would contain a `:` before the name was complete). So instead, I created a simple object format (with properties `name`, `repoUrl`, and `command`) that can be specified alongside strings.

I did my best not to editorialize on style or do any other refactors in the process, so even though this is a significant change, I tried to make it as non-disruptive to you and your style as I could.

A couple notes: 

* The module was previously splitting on `:` for non-URL module names, but since it had no useful effect previously, I doubt anyone will be broken by the fact I removed it in this commit
* `npm install https://github.com/testdouble/testdouble.js` works, so perhaps the custom work with `ggit` isn't necessary? I only glanced at it.
* A default timeout of 10 seconds seems much too short. I wasn't able to get much at all to finish in 10 seconds and it seemed like an unnecessary constraint placed by the module on users when a longer install doesn't suggest a failure
* It's pretty clear that dont-break doesn't delete test folders, at least not when things fail. (oops, this is a dupe of #33)

