### PR TITLE
Postinstall commands support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 npm-debug.log
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ save to `.dont-break.json` and check.
 
 The above commands overwrite `.dont-break.json` file.
 
-## Custom test command (in progress)
+## Custom test command
 
 You can specify a custom test command per dependent module. Separate the name of the module
 from the test command using `:` For example, to run `grunt test` for `foo-module-name`,
@@ -126,6 +126,23 @@ You can also specify a longer installation time out, in seconds, using CLI optio
 
 ```
 dont-break --timeout 30
+```
+
+## Custom post-install command
+
+Before testing the dependent package dont-break installs its dev dependencies via `npm install` command run from the 
+dependency directory. If you need something more you can specify it via "postinstall" config parameter like this: 
+```
+[
+  {
+    "name": "packageA",
+    "postinstall": "npm run update",
+    "test": "dont-break-tests-with-my-package.sh"
+  }, {
+    "name": "packageB",
+    "test": "dont-break-tests-with-my-package.sh"
+  }
+]
 ```
 
 ## Related

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ from the test command using `:` For example, to run `grunt test` for `foo-module
 but default command for module `bar-name`, list in `.dont-break.json` the following:
 
 ```
-foo-module-name: grunt test
-bar-name
+[{"name": "foo-module-name", "test": "grunt test"}, "bar-name"]
 ```
 
 You can also specify a longer installation time out, in seconds, using CLI option

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -177,6 +177,13 @@ function getDependentVersion (pkg, name) {
 }
 
 function testDependent (options, dependent) {
+  var moduleTestCommand
+  if (check.object(dependent)) {
+    moduleTestCommand = dependent.test
+    dependent = dependent.name
+  }
+  dependent = dependent.trim()
+
   la(check.unemptyString(dependent), 'invalid dependent', dependent)
   banner('  testing', quote(dependent))
 
@@ -192,12 +199,11 @@ function testDependent (options, dependent) {
     }
   }
 
-  // TODO grab test command from dependent object
   // var nameParts = dependent.split(NAME_COMMAND_SEPARATOR)
   // la(nameParts.length, 'expected at least module name', dependent)
   // var moduleName = nameParts[0].trim()
   // var moduleTestCommand = nameParts[1] || DEFAULT_TEST_COMMAND
-  var moduleTestCommand = DEFAULT_TEST_COMMAND
+  moduleTestCommand = moduleTestCommand || DEFAULT_TEST_COMMAND
   var testModuleInFolder = _.partial(testInFolder, moduleTestCommand)
 
   var pkg = require(join(process.cwd(), 'package.json'))
@@ -266,14 +272,13 @@ function testDependents (options, dependents) {
 }
 
 function dontBreakDependents (options, dependents) {
-  la(check.arrayOfStrings(dependents), 'invalid dependents', dependents)
+  la(check.arrayOf(check.object, dependents) || check.arrayOfStrings(dependents), 'invalid dependents', dependents)
   debug('dependents', dependents)
   if (check.empty(dependents)) {
     return Promise.resolve()
   }
 
-  dependents = dependents.map(s => s.trim())
-  banner('  testing the following dependents\n  ' + dependents)
+  banner('  testing the following dependents\n  ' + JSON.stringify(dependents))
 
   var logSuccess = function logSuccess () {
     console.log('all dependents tested')

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -178,8 +178,10 @@ function getDependentVersion (pkg, name) {
 
 function testDependent (options, dependent) {
   var moduleTestCommand
+  var modulePostinstallCommand
   if (check.object(dependent)) {
     moduleTestCommand = dependent.test
+    modulePostinstallCommand = dependent.postinstall
     dependent = dependent.name
   }
   dependent = dependent.trim()
@@ -245,7 +247,7 @@ function testDependent (options, dependent) {
       console.log('installing dev dependencies', folder)
       var cwd = process.cwd()
       process.chdir(folder)
-      return install({}).then(function () {
+      return install({postinstall: modulePostinstallCommand}).then(function () {
         console.log('restoring current directory', cwd)
         process.chdir(cwd)
         return folder


### PR DESCRIPTION
This can be handy in some cases - e.g. if the postinstall command is too heavy to declare it as package.json's `postinstall` script. Config example:
```
[
  {
    "name": "packageA",
    "postinstall": "npm run update",
    "test": "dont-break-tests-with-my-package.sh"
  }, {
    "name": "packageB",
    "test": "dont-break-tests-with-my-package.sh"
  }
]
```
