### PR TITLE
chore(publishing): switch to freeform-semantic-commit-analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "update-notifier": "2.2.0"
   },
   "devDependencies": {
+    "freeform-semantic-commit-analyzer": "^1.1.8",
     "git-issues": "1.3.1",
     "github-post-release": "1.13.1",
     "if-node-version": "^1.1.1",
@@ -93,7 +94,7 @@
     "e2e": "./test/e2e.sh"
   },
   "release": {
-    "analyzeCommits": "simple-commit-message",
+    "analyzeCommits": "freeform-semantic-commit-analyzer",
     "generateNotes": "github-post-release"
   }
 }


### PR DESCRIPTION
.. for chore commits to trigger releases, too

just observed that https://travis-ci.org/bahmutov/dont-break/builds/266033954 didn't see deps update as significant enough to release: 
![2017-08-18_1946](https://user-images.githubusercontent.com/11217/29468724-1af9f382-844e-11e7-9837-d97f746c01e3.png)
