### PR TITLE
Allow testing indirect dependents

### DIFF
--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -237,12 +237,12 @@ function testDependent (options, dependent) {
       var installedPackage = readJSON(join(folder, 'package.json'))
       var moduleVersion = installedPackage.version
       var currentVersion = getDependentVersion(installedPackage, pkg.name)
-      la(check.unemptyString(currentVersion),
-        'could not find dependency on', pkg.name,
-        'in module', installedPackage.name)
+      var usageMessage = currentVersion
+        ? '\ncurrently uses ' + pkg.name + '@' + currentVersion
+        : '\ncurrently not (directly) using ' + pkg.name
       banner('installed', moduleName + '@' + moduleVersion,
         '\ninto', folder,
-        '\ncurrently uses', pkg.name + '@' + currentVersion,
+        usageMessage,
         '\nwill test', pkg.name + '@' + pkg.version)
       return folder
     })


### PR DESCRIPTION
This change removes the restriction of testing only the direct dependents. This enables testing a deeper hierarchy when changing a leaf dependency.

In this example, it would be nice to know that the changes made to ```module A``` will not break any of the ```module B``` and ```module C```:
```
module C -> module B -> module A
```