### PR TITLE
fix: let 'postinstall' be run after installing current module to dependent, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,23 +131,6 @@ but default command for module `bar-name`, list in `.dont-break.json` the follow
 ]
 ```
 
-### Post-install command
-
-Before testing the dependent package dont-break installs its dev dependencies via `npm install` command run from the
-dependency directory. If you need something more you can specify it via "postinstall" config parameter like this:
-```
-[
-  {
-    "name": "packageA",
-    "postinstall": "npm run update",
-    "test": "dont-break-tests-with-my-package.sh"
-  }, {
-    "name": "packageB",
-    "test": "dont-break-tests-with-my-package.sh"
-  }
-]
-```
-
 ### Pre-testing with previous package version
 By default dont-break first tests dependent module with its published version of current module, to make sure that it 
 was working before the update. If this sounds excessive to you you can disable it with {"pretest": false} option: 
@@ -164,6 +147,25 @@ was working before the update. If this sounds excessive to you you can disable i
 Here "foo-module-name" module will be tested only once, and "bar-name" twise: first with its published version of 
 current module, and then with the updated version.   
 
+### Post-install command
+
+Before testing the dependent package dont-break installs its dev dependencies via `npm install` command run from the
+dependency directory. If you need something more you can specify it via "postinstall" config parameter like this:
+```
+[
+  {
+    "name": "packageA",
+    "postinstall": "npm run update",
+    "test": "dont-break-tests-with-my-package.sh"
+  }, {
+    "name": "packageB",
+    "test": "dont-break-tests-with-my-package.sh"
+  }
+]
+```
+If specified this command will run first before pretesting the old version of lib (if pretest isn't disabled), then 
+after installing current version of lib to dependent package.  
+ 
 ### Installation timeout
 You can specify a longer installation time out, in seconds, using CLI option
 

--- a/src/install-dependency.js
+++ b/src/install-dependency.js
@@ -10,9 +10,7 @@ var rimraf = require('rimraf')
 var chdir = require('chdir-promise')
 
 var npmInstall = require('npm-utils').install
-var postinstall = require('npm-utils').test
 la(check.fn(npmInstall), 'install should be a function', npmInstall)
-la(check.fn(postinstall), 'postinstall should be a function', postinstall)
 var cloneRepo = require('ggit').cloneRepo
 
 function removeFolder (folder) {
@@ -23,17 +21,6 @@ function removeFolder (folder) {
 }
 
 function install (options) {
-  var postInstall = function (arg) {
-    if (options.postinstall) {
-      console.log('running ' + options.postinstall + ' in %s', process.cwd())
-      return postinstall(options.postinstall).then(function () {
-        return arg
-      })
-    } else {
-      return arg
-    }
-  }
-
   if (isRepoUrl(options.name)) {
     debug('installing repo %s', options.name)
     removeFolder(options.prefix)
@@ -47,11 +34,9 @@ function install (options) {
     .then(function () {
       console.log('running NPM install in %s', process.cwd())
     })
-    .then(npmInstall)
-    .then(postInstall)
     .finally(chdir.from)
   } else {
-    return npmInstall(options).then(postInstall)
+    return npmInstall(options)
   }
 }
 


### PR DESCRIPTION
..and don't run it twice if no pretest is needed