### PR TITLE
feat(configuration): support 'npm link' current module installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,43 @@ save to `.dont-break.json` and check.
 The above commands overwrite `.dont-break.json` file.
 
 ## Configuration options
+
+### Global vs. project-level configuration
+You can specify different configuration options on global level or on project level. Following configs are equivalent.
+Project level:
+```
+[
+  {
+    "name": "project-a",
+    "test": "grunt test"
+  },
+  {
+    "name": "project-b",
+    "test": "grunt test"
+  },
+  {
+    "name": "project-c",
+    "test": "npm test:special"
+  }
+]
+```
+Global level:
+```
+{
+  "test": "grunt test",
+  "projects": [
+    "project-a", 
+    "project-b", 
+    {
+      "name": "project-c",
+      "test": "npm test:special"
+    }
+  ]
+}
+```
+Global level will simplify dont-break config if dependent projects share the same options. Also, options can be 
+overriden on project level as in case of "project-c" here.
+  
 ### Test command
 
 You can specify a custom test command per dependent module. For example, to run `grunt test` for `foo-module-name`,

--- a/README.md
+++ b/README.md
@@ -195,6 +195,20 @@ The "pretest" property can also accept custom script to run for pretesting:
 ```
 By default it equals to "test" command.
 
+### Current module installation method
+
+To test dependent package dont-break installs current module inside the dependent package directory. By default it uses
+`cd $DEPENDENT_PACKAGE_DIR && npm install $CURRENT_MODULE_DIR`. Other option is using [npm-link](https://docs.npmjs.com/cli/link) 
+for current module - this can be helpful in some cases, e.g. if you need to use `npm install` in postinstall command. 
+To use `npm link` method specify {"currentModuleInstall": "npm-link"}: 
+```
+{
+  "currentModuleInstall": "npm-link",
+  "projects": ["packageA", "packageB"]
+}
+```
+Default value is {"currentModuleInstall": "npm-install"}. 
+
 ### Post-install command
 
 Before testing the dependent package dont-break installs its dev dependencies via `npm install` command run from the

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -195,12 +195,12 @@ function postInstallInFolder (command, folder) {
   }
 }
 
-function testDependent (options, dependent) {
+function testDependent (options, dependent, config) {
   var moduleTestCommand
   var modulePostinstallCommand
   var testWithPreviousVersion = true
   if (check.object(dependent)) {
-    dependent = Object.assign({pretest: true}, dependent)
+    dependent = Object.assign({pretest: true}, config, dependent)
     moduleTestCommand = dependent.test
     modulePostinstallCommand = dependent.postinstall
     testWithPreviousVersion = dependent.pretest
@@ -302,19 +302,24 @@ function testDependent (options, dependent) {
     .then(testModuleInFolder)
 }
 
-function testDependents (options, dependents) {
-  la(check.array(dependents), 'expected dependents', dependents)
+function testDependents (options, config) {
+  la(check.array(config.projects), 'expected dependents', config.projects)
 
   // TODO switch to parallel testing!
-  return dependents.reduce(function (prev, dependent) {
+  return config.projects.reduce(function (prev, dependent) {
     return prev.then(function () {
-      return testDependent(options, dependent)
+      return testDependent(options, dependent, config)
     })
   }, Promise.resolve(true))
 }
 
 function dontBreakDependents (options, dependents) {
-  la(check.arrayOf(check.object, dependents) || check.arrayOfStrings(dependents), 'invalid dependents', dependents)
+  if (check.arrayOf(check.object, dependents) || check.arrayOfStrings(dependents)) {
+    dependents = {
+      projects: dependents
+    }
+  }
+  la(check.arrayOf(check.object, dependents.projects) || check.arrayOfStrings(dependents.projects), 'invalid dependents', dependents.projects)
   debug('dependents', dependents)
   if (check.empty(dependents)) {
     return Promise.resolve()

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -87,12 +87,10 @@ function getDependentsFromFile () {
     })
 }
 
-function _currentPackageName () {
+var currentPackageName = _.memoize(function () {
   var pkg = require(join(process.cwd(), 'package.json'))
   return pkg.name
-}
-
-var currentPackageName = _.memoize(_currentPackageName)
+})
 
 function getDependents (options, name) {
   options = options || {}

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -148,6 +148,13 @@ function runInFolder (folder, testCommand, messages) {
   })
 }
 
+var linkCurrentModule = _.memoize(function (thisFolder) {
+  return runInFolder(thisFolder, 'npm link', {
+    success: 'linking current module succeeded',
+    failure: 'linking current module failed'
+  })
+})
+
 function installCurrentModuleToDependent (dependentFolder, currentModuleInstallMethod) {
   la(check.unemptyString(dependentFolder), 'expected dependent folder', dependentFolder)
 
@@ -161,10 +168,7 @@ function installCurrentModuleToDependent (dependentFolder, currentModuleInstallM
 
   if (currentModuleInstallMethod === 'npm-link') {
     var pkgName = currentPackageName()
-    return runInFolder(thisFolder, 'npm link', {
-      success: 'linking current module succeeded',
-      failure: 'linking current module failed'
-    })
+    return linkCurrentModule(thisFolder)
       .then(function () {
         return runInFolder(dependentFolder, `npm link ${pkgName}`, {
           success: `linked ${pkgName}`,

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -87,13 +87,19 @@ function getDependentsFromFile () {
     })
 }
 
+function _currentPackageName () {
+  var pkg = require(join(process.cwd(), 'package.json'))
+  return pkg.name
+}
+
+var currentPackageName = _.memoize(_currentPackageName)
+
 function getDependents (options, name) {
   options = options || {}
   var forName = name
 
   if (!name) {
-    var pkg = require(join(process.cwd(), 'package.json'))
-    forName = pkg.name
+    forName = currentPackageName()
   }
 
   var firstStep
@@ -116,24 +122,24 @@ function getDependents (options, name) {
 }
 
 function testInFolder (testCommand, folder) {
-  return runInFolder(testCommand, folder, {
+  return runInFolder(folder, testCommand, {
     missing: 'missing test command',
-    success: 'tests work in',
-    failure: 'tests did not work in'
+    success: 'tests work',
+    failure: 'tests did not work'
   })
 }
 
-function runInFolder (testCommand, folder, messages) {
+function runInFolder (folder, testCommand, messages) {
   la(check.unemptyString(testCommand), messages.missing, testCommand)
   la(check.unemptyString(folder), 'expected folder', folder)
   var cwd = process.cwd()
   process.chdir(folder)
   return npmTest(testCommand).then(function () {
-    console.log(messages.success, folder)
+    console.log(`${messages.success} in ${folder}`)
     return folder
   })
   .catch(function (errors) {
-    console.error(messages.failure, folder)
+    console.error(`${messages.failure} in ${folder}`)
     console.error('code', errors.code)
     throw errors
   })
@@ -142,7 +148,7 @@ function runInFolder (testCommand, folder, messages) {
   })
 }
 
-function installCurrentModuleToDependent (dependentFolder) {
+function installCurrentModuleToDependent (dependentFolder, currentModuleInstallMethod) {
   la(check.unemptyString(dependentFolder), 'expected dependent folder', dependentFolder)
 
   debug('testing the current module in %s', dependentFolder)
@@ -153,15 +159,33 @@ function installCurrentModuleToDependent (dependentFolder) {
     name: thisFolder
   }
 
-  return chdir.to(dependentFolder)
-    .then(function () { return npmInstall(options) })
-    .then(function () {
-      console.log('Installed\n %s\n in %s', thisFolder, dependentFolder)
+  if (currentModuleInstallMethod === 'npm-link') {
+    var pkgName = currentPackageName()
+    return runInFolder(thisFolder, 'npm link', {
+      success: 'linking current module succeeded',
+      failure: 'linking current module failed'
     })
-    .finally(chdir.from)
-    .then(function () {
-      return dependentFolder
-    })
+      .then(function () {
+        return runInFolder(dependentFolder, `npm link ${pkgName}`, {
+          success: `linked ${pkgName}`,
+          failure: `linking ${pkgName} failed`
+        })
+      })
+      .finally(chdir.from)
+      .then(function () {
+        return dependentFolder
+      })
+  } else {
+    return chdir.to(dependentFolder)
+      .then(function () { return npmInstall(options) })
+      .then(function () {
+        console.log('Installed\n %s\n in %s', thisFolder, dependentFolder)
+      })
+      .finally(chdir.from)
+      .then(function () {
+        return dependentFolder
+      })
+  }
 }
 
 function getDependencyName (dependent) {
@@ -186,9 +210,9 @@ function getDependentVersion (pkg, name) {
 
 function postInstallInFolder (command, folder) {
   if (command) {
-    return runInFolder(command, folder, {
-      success: 'postinstall succeeded in',
-      failure: 'postinstall did not work in'
+    return runInFolder(folder, command, {
+      success: 'postinstall succeeded',
+      failure: 'postinstall did not work'
     })
   } else {
     return folder
@@ -198,15 +222,18 @@ function postInstallInFolder (command, folder) {
 function testDependent (options, dependent, config) {
   var moduleTestCommand
   var modulePostinstallCommand
-  var testWithPreviousVersion = true
-  if (check.object(dependent)) {
-    dependent = Object.assign({pretest: true}, config, dependent)
-    moduleTestCommand = dependent.test
-    modulePostinstallCommand = dependent.postinstall
-    testWithPreviousVersion = dependent.pretest
-    dependent = dependent.name
+  var testWithPreviousVersion
+  var currentModuleInstallMethod
+  if (check.string(dependent)) {
+    dependent = {name: dependent.trim()}
   }
-  dependent = dependent.trim()
+
+  dependent = Object.assign({pretest: true, currentModuleInstall: 'npm-install'}, config, dependent)
+  moduleTestCommand = dependent.test
+  modulePostinstallCommand = dependent.postinstall
+  testWithPreviousVersion = dependent.pretest
+  currentModuleInstallMethod = dependent.currentModuleInstall
+  dependent = dependent.name
 
   la(check.unemptyString(dependent), 'invalid dependent', dependent)
   banner('  testing', quote(dependent))
@@ -297,7 +324,7 @@ function testDependent (options, dependent, config) {
   }
 
   return res
-    .then(installCurrentModuleToDependent)
+    .then(function (folder) { return installCurrentModuleToDependent(folder, currentModuleInstallMethod) })
     .then(postInstallModuleInFolder)
     .then(testModuleInFolder)
 }

--- a/test/configs/.dont-break.globals.json
+++ b/test/configs/.dont-break.globals.json
@@ -1,10 +1,11 @@
 {
-  "test": "node index.js",
+  "test": "error",
+  "pretest": false,
   "projects": [
     {
       "name": "https://github.com/bahmutov/dont-break-bar",
-      "pretest": false,
-      "postinstall": "rm package.json"
+      "postinstall": "rm package.json",
+      "test": "node index.js"
     }
   ]
 }

--- a/test/configs/.dont-break.globals.json
+++ b/test/configs/.dont-break.globals.json
@@ -1,0 +1,10 @@
+{
+  "test": "node index.js",
+  "projects": [
+    {
+      "name": "https://github.com/bahmutov/dont-break-bar",
+      "pretest": false,
+      "postinstall": "rm package.json"
+    }
+  ]
+}

--- a/test/configs/.dont-break.globals.json
+++ b/test/configs/.dont-break.globals.json
@@ -1,7 +1,6 @@
 {
   "test": "error",
   "pretest": false,
-  "currentModuleInstall": "npm-link",
   "projects": [
     {
       "name": "https://github.com/bahmutov/dont-break-bar",

--- a/test/configs/.dont-break.globals.json
+++ b/test/configs/.dont-break.globals.json
@@ -1,6 +1,7 @@
 {
   "test": "error",
   "pretest": false,
+  "currentModuleInstall": "npm-link",
   "projects": [
     {
       "name": "https://github.com/bahmutov/dont-break-bar",

--- a/test/configs/.dont-break.npm-link.json
+++ b/test/configs/.dont-break.npm-link.json
@@ -1,0 +1,5 @@
+{
+  "pretest": false,
+  "currentModuleInstall": "npm-link",
+  "projects": ["https://github.com/bahmutov/dont-break-bar", "https://github.com/bahmutov/dont-break-bar"]
+}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -7,6 +7,7 @@ echo "Testing dont-break"
 npm link
 echo "Linked current dont-break to global"
 
+BASEDIR=$(pwd)
 echo "Creating test folder"
 folder=/tmp/test-dont-break
 rm -rf $folder
@@ -18,5 +19,7 @@ echo "Cloning first module"
 git clone https://github.com/bahmutov/dont-break-foo.git
 cd dont-break-foo
 npm install --prod
+npm run dont-break
+cp -f $BASEDIR/test/configs/.dont-break.globals.json ./.dont-break.json
 npm run dont-break
 echo "dont-break is working"

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e
+
 echo "Testing dont-break"
 
 npm link

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -22,4 +22,6 @@ npm install --prod
 npm run dont-break
 cp -f $BASEDIR/test/configs/.dont-break.globals.json ./.dont-break.json
 npm run dont-break
+cp -f $BASEDIR/test/configs/.dont-break.npm-link.json ./.dont-break.json
+npm run dont-break
 echo "dont-break is working"


### PR DESCRIPTION
This can be helpful in some cases, e.g. if you need to use `npm install` in postinstall command (like I do in one of projects).

Includes https://github.com/bahmutov/dont-break/pull/60