### PR TITLE
fix: support mixed project types

### DIFF
--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -327,7 +327,7 @@ function dontBreakDependents (options, dependents) {
       projects: dependents
     }
   }
-  la(check.arrayOf(function(item) {
+  la(check.arrayOf(function (item) {
     return check.object(item) || check.string(item)
   }, dependents.projects), 'invalid dependents', dependents.projects)
   debug('dependents', dependents)

--- a/src/dont-break.js
+++ b/src/dont-break.js
@@ -327,7 +327,9 @@ function dontBreakDependents (options, dependents) {
       projects: dependents
     }
   }
-  la(check.arrayOf(check.object, dependents.projects) || check.arrayOfStrings(dependents.projects), 'invalid dependents', dependents.projects)
+  la(check.arrayOf(function(item) {
+    return check.object(item) || check.string(item)
+  }, dependents.projects), 'invalid dependents', dependents.projects)
   debug('dependents', dependents)
   if (check.empty(dependents)) {
     return Promise.resolve()


### PR DESCRIPTION
..some can be Objects and some strings, like in README:
```
{
  "test": "grunt test",
  "projects": [
    "project-a",
    "project-b",
    {
      "name": "project-c",
      "test": "npm test:special"
    }
  ]
}
```