### PR TITLE
fix: corrected `install` step for NPM dependencies

### DIFF
--- a/src/install-dependency.js
+++ b/src/install-dependency.js
@@ -40,7 +40,7 @@ function install (options) {
     if (options.name) {
       cmd = `${cmd} ${options.name}`
     }
-    res = Promise.resolve()
+    res = q([])
   }
 
   return res.then(function () {


### PR DESCRIPTION
need to use `q` instead of `Promise` here because Promises don't have .timeout method